### PR TITLE
Fixing bug where tvservice needs to be restarted

### DIFF
--- a/hdmi_cec_to_adb/bin/start_hdmi_cec_monitor.py
+++ b/hdmi_cec_to_adb/bin/start_hdmi_cec_monitor.py
@@ -125,6 +125,7 @@ class Monitor:
         background_thread = Thread(target=Monitor.timer)
         background_thread.start()
 
+
 def main():
     parser = argparse.ArgumentParser(description='Start the HDMI CEC Monitor.')
     parser.add_argument('--tv_ip_address', type=str, help='The IP address of the Android TV')

--- a/hdmi_cec_to_adb/bin/start_hdmi_cec_monitor.py
+++ b/hdmi_cec_to_adb/bin/start_hdmi_cec_monitor.py
@@ -99,7 +99,14 @@ class Monitor:
             logger.debug('Standby command received')
             self.turn_off_tv()
 
+    @staticmethod
+    def turn_off_tvservice():
+        tvservice_command = subprocess.run(['tvservice', '--off'], stdout=subprocess.PIPE, text=True)
+        if tvservice_command.returncode != 0:
+            raise ValueError('Could not stop tvservice [tvservice_command.stdout=%s]' % tvservice_command.stdout)
+
     def configure_cec(self):
+        self.turn_off_tvservice()
         cec.init()
         cec.add_callback(self.cec_callback, cec.EVENT_ALL)
 
@@ -117,7 +124,6 @@ class Monitor:
         logger.info('Starting background thread')
         background_thread = Thread(target=Monitor.timer)
         background_thread.start()
-
 
 def main():
     parser = argparse.ArgumentParser(description='Start the HDMI CEC Monitor.')

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open('README.md', 'r') as f:
     readme = f.read()
 
 setup(name='hdmi-cec-to-adb',
-      version='0.1.0.dev6',
+      version='0.2',
       author='Paul Pavlish',
       author_email='hello@paulpavlish.com',
       url='https://github.com/paulsaccount/hdmi_cec_to_adb',


### PR DESCRIPTION
Fixes issue where Raspberry `tvservice` needs to be restarted before starting `hdmi_cec_to_adb`